### PR TITLE
Refactoring newsapi v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ import (
 func main() {
 	c := newsapi.NewClient("<API KEY>", newsapi.WithHTTPClient(http.DefaultClient))
 
-	sources, _, err := c.GetSources(context.Background(), &newsapi.SourceParameters{
+	sources, err := c.GetSources(context.Background(), &newsapi.SourceParameters{
 		Country: "gb",
 	})
 
@@ -95,7 +95,7 @@ import (
 func main() {
 	c := newsapi.NewClient("<API KEY>", newsapi.WithHTTPClient(http.DefaultClient))
 
-	articles, _, err := c.GetTopHeadlines(context.Background(), &newsapi.ArticleParameters{
+	articles, err := c.GetTopHeadlines(context.Background(), &newsapi.TopHeadlineParameters{
 		Sources: []string{ "cnn", "time" },
 	})
 
@@ -125,7 +125,7 @@ import (
 func main() {
 	c := newsapi.NewClient("<API KEY>", newsapi.WithHTTPClient(http.DefaultClient))
 
-	articles, _, err := c.GetEverything(context.Background(), &newsapi.ArticleParameters{
+	articles, err := c.GetEverything(context.Background(), &newsapi.EverythingParameters{
 		Sources: []string{ "cnn", "time" },
 	})
 

--- a/article.go
+++ b/article.go
@@ -10,7 +10,7 @@ import (
 
 // ArticleParameters are the parameters used for the newsapi article endpoint
 // Source must always contain a value
-// See http://beta.newsapi.org/docs for more information on the required parameters
+// See http://newsapi.org/docs for more information on the required parameters
 type ArticleParameters struct {
 	Sources []string `url:"sources,omitempty,comma"`
 	Domains []string `url:"domains,omitempty,comma"`
@@ -46,21 +46,21 @@ type ArticleResponse struct {
 }
 
 // GetTopHeadlines returns the articles from newsapi
-// See http://beta.newsapi.org/docs for more information
+// See http://newsapi.org/docs for more information
 // It will return the error from newsapi if there is an error
 func (c *Client) GetTopHeadlines(ctx context.Context, params *ArticleParameters) (*ArticleResponse, *http.Response, error) {
 	return c.getArticles(ctx, "top-headlines", params)
 }
 
 // GetEverything returns the articles from newsapi
-// See http://beta.newsapi.org/docs for more information
+// See http://newsapi.org/docs for more information
 // It will return the error from newsapi if there is an error
 func (c *Client) GetEverything(ctx context.Context, params *ArticleParameters) (*ArticleResponse, *http.Response, error) {
 	return c.getArticles(ctx, "everything", params)
 }
 
 // GetArticles returns the articles from newsapi
-// See http://beta.newsapi.org/docs for more information
+// See http://newsapi.org/docs for more information
 // It will return the error from newsapi if there is an error
 func (c *Client) getArticles(ctx context.Context, u string, params *ArticleParameters) (*ArticleResponse, *http.Response, error) {
 	if params == nil {

--- a/article.go
+++ b/article.go
@@ -20,6 +20,9 @@ type ArticleParameters struct {
 	Language string `url:"language,omitempty"`
 	SortBy   string `url:"sortBy,omitempty"`
 	Page     int    `url:"page,omitempty"`
+
+	From time.Time `url:"from,omitempty"`
+	To   time.Time `url:"to,omitempty"`
 }
 
 // Article is a single article from the newsapi article response

--- a/error.go
+++ b/error.go
@@ -1,0 +1,19 @@
+package newsapi
+
+import "fmt"
+
+// Error defines an API error from newsapi.
+type Error struct {
+	Code    string `json:"code,omitempty"`
+	Message string `json:"message,omitempty"`
+}
+
+func (e Error) Error() string {
+	return fmt.Sprintf("[%s] %s", e.Code, e.Message)
+}
+
+// APIError returns if the given err is of type `newsapi.Error`.
+func APIError(err error) bool {
+	_, ok := err.(*Error)
+	return ok
+}

--- a/sources.go
+++ b/sources.go
@@ -2,7 +2,6 @@ package newsapi
 
 import (
 	"context"
-	"net/http"
 )
 
 // SourceParameters are the parameters which can be used in the source request to newsapi
@@ -35,7 +34,7 @@ type SourceResponse struct {
 }
 
 // GetSources returns the sources from newsapi see http://beta.newsapi.org/docs for more information on the parameters
-func (c *Client) GetSources(ctx context.Context, params *SourceParameters) (*SourceResponse, *http.Response, error) {
+func (c *Client) GetSources(ctx context.Context, params *SourceParameters) (*SourceResponse, error) {
 	u := "sources"
 
 	if params != nil {
@@ -43,22 +42,28 @@ func (c *Client) GetSources(ctx context.Context, params *SourceParameters) (*Sou
 		u, err = setOptions(u, params)
 
 		if err != nil {
-			return nil, nil, err
+			return nil, err
 		}
 	}
 
 	req, err := c.newGetRequest(u)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
-	var response *SourceResponse
+	var response = struct {
+		*Error
+		*SourceResponse
+	}{}
 
-	resp, err := c.do(ctx, req, &response)
-
+	_, err = c.do(ctx, req, &response)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
-	return response, resp, nil
+	if response.Error != nil {
+		return nil, response.Error
+	}
+
+	return response.SourceResponse, nil
 }


### PR DESCRIPTION
This pull requests updates the old api to use the v2 api. It also improved error handling and made sure that no `*http.Response` was leaking into other parts of the code. Further more there is support for go modules (go1.11beta) feature.